### PR TITLE
Build static binaries in addition to dynamically linked ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,19 @@ rust: stable
 env:
   global:
   - THERMITE_DEBUG_FILENAME: /tmp/thermite-debug.log
-  matrix:
   - T12R_RUBY_VERSION: 2.4.2
 matrix:
   include:
   - os: osx
     osx_image: xcode8
+  - os: linux
+    env: RUBY_STATIC=1
+  - os: osx
+    osx_image: xcode8.3
+    env: RUBY_STATIC=1
+  - os: osx
+    osx_image: xcode8
+    env: RUBY_STATIC=1
 
 cache:
   cargo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
   - THERMITE_DEBUG_FILENAME: /tmp/thermite-debug.log
   matrix:
-  - T12R_RUBY_VERSION: 2.3.1
+  - T12R_RUBY_VERSION: 2.4.2
 matrix:
   include:
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 - linux
 - osx
 dist: trusty
-osx_image: xcode8.3
+osx_image: xcode9
 rust: stable
 env:
   global:
@@ -17,7 +17,7 @@ matrix:
   - os: linux
     env: RUBY_STATIC=1
   - os: osx
-    osx_image: xcode8.3
+    osx_image: xcode9
     env: RUBY_STATIC=1
   - os: osx
     osx_image: xcode8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 ruru = "0.9"
 unidecode = "0.3"
 
+[replace]
+"ruby-sys:0.2.20" = { git = "http://github.com/malept/ruby-sys", branch = "test-osx-and-static-builds" }
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ out-of-the-box.
 
 ## Requirements
 
-* Ruby ≥ 2.3 (built with shared libraries)
+* Ruby ≥ 2.4 (built with shared libraries)
 * [Rust](http://www.rust-lang.org/) (if you build from source)
 
 If you're using t12r on OSX without Rust installed, please note that the prebuilt binaries are built

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you're using t12r on OSX without Rust installed, please note that the prebuil
 with the following xcode versions:
 
 * OSX 10.11: xcode 8.0
-* OSX 10.12: xcode 8.1
+* OSX 10.12: xcode 9.0
 
 ## Usage
 

--- a/t12r.gemspec
+++ b/t12r.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
 
   s.extensions << 'ext/Rakefile'
 
-  s.add_runtime_dependency 'thermite', '~> 0.10'
+  s.add_runtime_dependency 'thermite', '~> 0.13'
 end


### PR DESCRIPTION
Newly added in [Thermite 0.13.0](https://github.com/malept/thermite/releases/tag/v0.13.0). Also requires a branch of ruby-sys, as the latest version of ruby-sys doesn't support macOS and also isn't compatible with the current version of ruru.

Needed to bump the 10.12 binary to use Xcode 9.0 because of what's available in Travis CI's images.

Addresses #1.