### PR TITLE
Only build statically linked extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,24 @@
-sudo: false
 language: rust
 os:
 - linux
 - osx
-dist: trusty
-osx_image: xcode9
+dist: xenial
+# macOS 10.12
+osx_image: xcode9.2
 rust: stable
 env:
   global:
+  - RUBY_STATIC: 1
   - THERMITE_DEBUG_FILENAME: /tmp/thermite-debug.log
-  - T12R_RUBY_VERSION: 2.4.2
+  - T12R_RUBY_VERSION: 2.4.5
 matrix:
   include:
+  # macOS 10.13
   - os: osx
-    osx_image: xcode8
-  - os: linux
-    env: RUBY_STATIC=1
+    osx_image: xcode10.1
+  # macOS 10.14
   - os: osx
-    osx_image: xcode9
-    env: RUBY_STATIC=1
-  - os: osx
-    osx_image: xcode8
-    env: RUBY_STATIC=1
+    osx_image: xcode10.2
 
 cache:
   cargo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
 - linux
 - osx
 dist: xenial
-# macOS 10.12
-osx_image: xcode9.2
+# macOS 10.13
+osx_image: xcode10.1
 rust: stable
 env:
   global:
@@ -13,9 +13,6 @@ env:
   - T12R_RUBY_VERSION: 2.4.5
 matrix:
   include:
-  # macOS 10.13
-  - os: osx
-    osx_image: xcode10.1
   # macOS 10.14
   - os: osx
     osx_image: xcode10.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
   # macOS 10.14
   - os: osx
     osx_image: xcode10.2
+branches:
+  only:
+  - master
+  - /^v\d+\.\d+\.\d+/
 
 cache:
   cargo: true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ out-of-the-box.
 
 ## Requirements
 
-* Ruby ≥ 2.4 (built with shared libraries)
+* Ruby ≥ 2.4
 * [Rust](http://www.rust-lang.org/) (if you build from source)
 
 If you're using t12r on OSX without Rust installed, please note that the prebuilt binaries are built

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ out-of-the-box.
 * Ruby ≥ 2.4
 * [Rust](http://www.rust-lang.org/) (if you build from source)
 
-If you're using t12r on OSX without Rust installed, please note that the prebuilt binaries are built
+If you're using t12r on macOS without Rust installed, please note that the prebuilt binaries are built
 with the following xcode versions:
 
-* OSX 10.11: xcode 8.0
-* OSX 10.12: xcode 9.0
+* macOS 10.13: xcode 10.1
+* macOS 10.14: xcode 10.2
 
-Since they are built on Travis CI, prebuilt OSX binaries may require libgmp (`brew install gmp`
+Since they are built on Travis CI, prebuilt macOS binaries may require libgmp (`brew install gmp`
 or equivalent).
 
 ## Usage


### PR DESCRIPTION
Asking developers to build a Ruby with `--enable-shared` is too much work.

Updates the docs accordingly.